### PR TITLE
Provide custom settings for user data location.

### DIFF
--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -77,7 +77,10 @@
 
 (defvar dictionary-overlay-just-unknown-words t)
 
-(defvar dictionary-overlay-user-data-directory "~/.emacs.d/dictionary-overlay-data")
+(defcustom dictionary-overlay-user-data-directory
+  (concat (file-name-parent-directory user-init-file)
+          "dictionary-overlay-data/")
+  "Place user data in Emacs directory.")
 
 (defun dictionary-overlay-start ()
   "Start dictionary-overlay."


### PR DESCRIPTION
Why this commit:
1. Provide custom settings for user data location.
2. Hard-coded user data directory in home directory would break user's  
personal config if located at other directory, say, `~/.config/emacs`,  
since Emacs use `~/.emacs.d/` if exists.