### PR TITLE
Provide function to exit dictionary-overlay

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,6 +44,7 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | 命令                                        | 说明                                                       |
 |---------------------------------------------+------------------------------------------------------------|
 | dictionary-overlay-start                    | 启动 dictionary-overlay 应用                               |
+| dictionary-overlay-stop                     | 退出 dictionary-overlay 应用                               |
 | dictionary-overlay-restart                  | 重启 dictionary-overlay 应用                               |
 | dictionary-overlay-render-buffer            | 使用翻译渲染当前 buffer                                    |
 | dictionary-overlay-toggle                   | 打开\关闭翻译渲染当前 buffer                               |
@@ -63,12 +64,12 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-just-unknown-words  | t 时使用“生词本”模式，nil 为“透析阅读”模式，默认为 t               |
 | dictionary-overlay-user-data-directory | 用户数据存放的目录，默认值为：“~/.emacs.d/dictionary-overlay-data” |
 | dictionary-overlay-translation-format  | 翻译展示的形式，默认是："(%s)"                                     |
-| dictionary-overlay-unknownword         | 生词的展示形态face 默认为nil, 用户可自行修改                       |
-| dictionary-overlay-translation         | 生词的翻译的展示形态 face 默认为nil, 用户可自行修改                |
+| dictionary-overlay-unknownword         | 生词的展示形态 face 默认为 nil, 用户可自行修改                       |
+| dictionary-overlay-translation         | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |
 
 ** face
 
-用于控制生词的展示, 为了不影响阅读默认为空，不对原始face 做任何修改。如果希望能通过face 对生词进行显示增加可以参考
+用于控制生词的展示, 为了不影响阅读默认为空，不对原始 face 做任何修改。如果希望能通过 face 对生词进行显示增加可以参考
 
 #+begin_src emacs-lisp
 (defface dictionary-overlay-translation
@@ -81,7 +82,7 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
   "Face for dictionary-overlay unknown words.")
 #+end_src
 
-face `dictionary-overlay-unknownword` 如果用户不自行定义，那么不会给单词加上overlay, 只会新增翻译的 overlay. 这样的好处是，当你在单词上移动时，仍旧按照字母移动，而不是按照overlay 移动。
+face `dictionary-overlay-unknownword` 如果用户不自行定义，那么不会给单词加上 overlay, 只会新增翻译的 overlay. 这样的好处是，当你在单词上移动时，仍旧按照字母移动，而不是按照 overlay 移动。
 
 推荐使用的 face ：
 #+begin_src emacs-lisp
@@ -105,5 +106,5 @@ face `dictionary-overlay-unknownword` 如果用户不自行定义，那么不会
 当你阅读了足够多的文章，你应该积累了一定量的 know-words ，此时，或许你可以尝试使用"透析阅读法"（ ~(setq dictionary-overlay-just-unknown-words nil)~ ）将自动展示，“或许”你不认识的单词。
 
 * 功能特性
-- 使用 snowballstemmer进行词干提取，能够用于标记词干相同，形态不一的单词
+- 使用 snowballstemmer 进行词干提取，能够用于标记词干相同，形态不一的单词
 - 增加翻译修改功能，允许用户选择合适的词意

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -28,6 +28,8 @@
 ;;
 ;;  `dictionary-overlay-start'
 ;;    Start dictionary-overlay.
+;;  `dictionary-overlay-stop'
+;;    Stop dictionary-overlay.
 ;;  `dictionary-overlay-restart'
 ;;    Restart dictionary-overlay and show process.
 ;;  `dictionary-overlay-render-buffer'
@@ -124,6 +126,11 @@ If nil, show overlay for words not in knownwords list."
    "dictionary-overlay"
    "python3"
    dictionary-overlay-py-path))
+
+(defun dictionary-overlay-stop ()
+  "Stop dictionary-overlay."
+  (interactive)
+  (websocket-bridge-app-exit "dictionary-overlay"))
 
 (defun dictionary-overlay-restart ()
   "Restart dictionary-overlay and show process."

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -133,13 +133,16 @@ If nil, show overlay for words not in knownwords list."
   (websocket-bridge-app-exit "dictionary-overlay"))
 
 (defun dictionary-overlay-restart ()
-  "Restart dictionary-overlay and show process."
+  "Restart dictionary-overlay."
   (interactive)
-  (websocket-bridge-app-exit "dictionary-overlay")
+  (dictionary-overlay-stop)
   (dictionary-overlay-start)
-  (split-window-below)
-  (websocket-bridge-app-open-buffer "dictionary-overlay"))
-
+  ;; REVIEW: really need bring this buffer to front? or we place it at bottom?
+  ;; (split-window-below)
+  ;; (split-window-below -10)
+  ;; (other-window 1)
+  ;; (websocket-bridge-app-open-buffer "dictionary-overlay")
+  )
 
 (defun websocket-bridge-call-buffer(func-name)
   "Call grammarly function on current buffer by FUNC-NAME."
@@ -151,7 +154,6 @@ If nil, show overlay for words not in knownwords list."
   "Call grammarly function on current word by FUNC-NAME."
   (websocket-bridge-call "dictionary-overlay" func-name
                          (downcase (thing-at-point 'word))))
-
 
 (defun dictionary-overlay-render-buffer ()
   "Render current buffer."


### PR DESCRIPTION
功能：补充一个退出命令： `M-x dictionary-overlay-stop RET`
原因：有时退出渲染过的buffer后，后台还在跑。