### PR TITLE
Option to choose where to show overlay

### DIFF
--- a/README.org
+++ b/README.org
@@ -61,12 +61,13 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 * 选项
 
 | 选项                                               | 说明                                                          |
-| dictionary-overlay-just-unknown-words             | t 时使用“生词本”模式，nil 为“透析阅读”模式，默认为 t                 |
-| dictionary-overlay-refresh-buffer-after-mark-word | t 时每次标记“单个词”都会重新渲染整个buffer, 默认为 t                 |
+| dictionary-overlay-just-unknown-words             | t 时使用“生词本”模式，nil 为“透析阅读”模式，默认为 t                |
+| dictionary-overlay-refresh-buffer-after-mark-word | t 时每次标记“单个词”都会重新渲染整个buffer, 默认为 t                |
 | dictionary-overlay-user-data-directory            | 用户数据存放 目录，默认值为：“~/.emacs.d/dictionary-overlay-data” |
-| dictionary-overlay-translation-format             | 翻译展示的形式，默认是："(%s)"                                    |
-| dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                      |
-| dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                 |
+| dictionary-overlay-position                       | 显示翻译的位置：词后，help-echo, 默认在词后                       |
+| dictionary-overlay-translation-format             | 翻译展示的形式，默认是："(%s)"                                   |
+| dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                     |
+| dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |
 
 
 ** face
@@ -105,9 +106,11 @@ face `dictionary-overlay-unknownword` 如果用户不自行定义，那么不会
 
 当一个生词反复出现，你觉得自己已经认识了它，可以标记为 known （ ~dictionary-overlay-mark-word-known~ ），下次不再展示翻译。
 
-当你阅读了足够多的文章，你应该积累了一定量的 know-words ，此时，或许你可以尝试使用"透析阅读法"（ ~(setq dictionary-overlay-just-unknown-words nil)~ ）将自动展示，“或许”你不认识的单词。
+当你阅读了足够多的文章，你应该积累了一定量的 known-words ，此时，或许你可以尝试使用"透析阅读法"（ ~(setq dictionary-overlay-just-unknown-words nil)~ ）将自动展示，“或许”你不认识的单词。
 
 当前 buffer 有大量生词时，重新渲染整个界面会产生可感知的渲染延迟，此时可将 dictionary-overlay-refresh-buffer-after-mark-word 的值设为 nil, 界面不再刷新，但词汇依然会进入生词本和熟词本，如果标记几个词后想刷新界面，可使用命令 dictionary-overlay-render-buffer。
+
+如果喜欢最小的视觉干扰，可以通过 (setq dictionary-overlay-position 'help-echo) 把翻译位置设置在 help-echo 里，只有鼠标通过时才显示释义。注意：目前支持的释义仍过于简单，并不推荐使用此法，同时由于默认无face，推荐设置前述 (copy-face 'font-lock-keyword-face 'dictionary-overlay-unknownword)。
 
 * 功能特性
 - 使用 snowballstemmer 进行词干提取，能够用于标记词干相同，形态不一的单词

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -86,18 +86,13 @@
   "Dictionary overlay for words in buffers."
   :group 'applications)
 
-(defface dictionary-overlay-unknownword
-  nil
+(defface dictionary-overlay-unknownword nil
   "Face for dictionary-overlay unknown words."
-  :group 'dictionary-overlay
-  )
+  :group 'dictionary-overlay)
 
-(defface dictionary-overlay-translation
-  nil
+(defface dictionary-overlay-translation nil
   "Face for dictionary-overlay translations."
-  :group 'dictionary-overlay
-  )
-
+  :group 'dictionary-overlay)
 
 (defvar dictionary-overlay-py-path
   (concat (file-name-directory load-file-name)
@@ -114,7 +109,7 @@
   "If t, show overlay for words in unknownwords list.
 If nil, show overlay for words not in knownwords list."
   :group 'dictionary-overlay
-  :type 'boolean)
+  :type '(boolean))
 
 (defcustom dictionary-overlay-refresh-buffer-after-mark-word t
   "Refresh buffer or not after marking word as known or unknown.
@@ -122,22 +117,23 @@ Since overlay re-rendering for the whole buffer and word processing
 simultaneously causes noticeable flickering. Refresh buffer manually
 with `dictionary-overlay-render-buffer'."
   :group 'dictionary-overlay
-  :type 'boolean)
+  :type '(boolean))
 
 (defcustom dictionary-overlay-user-data-directory
   (locate-user-emacs-file "dictionary-overlay-data/")
   "Place user data in Emacs directory."
   :group 'dictionary-overlay
-  :type 'directory)
+  :type '(directory))
 
 (defcustom dictionary-overlay-translation-format "(%s)"
   "Translation format."
   :group 'dictionary-overlay
-  :type 'boolean)
+  :type '(string))
 
-(defcustom dictionary-overlay-crow-engine "google"
-  "Crow translate engine"
-  :group 'dictionary-overlay)
+(defcustom dictionary-overlay-crow-engine "Google"
+  "Crow translate engine."
+  :group 'dictionary-overlay
+  :type '(string))
 
 (defun dictionary-overlay-start ()
   "Start dictionary-overlay."
@@ -164,7 +160,7 @@ with `dictionary-overlay-render-buffer'."
   ;; (websocket-bridge-app-open-buffer "dictionary-overlay")
   )
 
-(defun websocket-bridge-call-buffer(func-name)
+(defun websocket-bridge-call-buffer (func-name)
   "Call grammarly function on current buffer by FUNC-NAME."
   (websocket-bridge-call "dictionary-overlay" func-name
                          (buffer-string)
@@ -238,7 +234,7 @@ with `dictionary-overlay-render-buffer'."
     (websocket-bridge-call-buffer "mark_buffer_unknown")
     (dictionary-overlay-refresh-buffer)))
 
-(defun dictionary-add-overlay-from (begin end source target)
+(defun dictionary-add-overlay-from (begin end _source target)
   "Add a overlay with range BEGIN to END for the translation SOURCE to TARGET."
   (when (not (face-equal 'dictionary-overlay-unknownword (make-face 'dictionary-overlay-default)))
     ;; when not add user face for the word, don't need a overlay in the origin word.

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -141,7 +141,7 @@ with `dictionary-overlay-render-buffer'."
   :group 'dictionary-overlay
   :type '(string))
 
-(defcustom dictionary-overlay-crow-engine "Google"
+(defcustom dictionary-overlay-crow-engine "google"
   "Crow translate engine."
   :group 'dictionary-overlay
   :type '(string))

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -81,7 +81,6 @@
 
 (require 'websocket-bridge)
 
-
 (defgroup dictionary-overlay ()
   "Dictionary overlay for words in buffers."
   :group 'applications)
@@ -154,7 +153,6 @@ with `dictionary-overlay-render-buffer'."
   (dictionary-overlay-stop)
   (dictionary-overlay-start)
   ;; REVIEW: really need bring this buffer to front? or we place it at bottom?
-  ;; (split-window-below)
   ;; (split-window-below -10)
   ;; (other-window 1)
   ;; (websocket-bridge-app-open-buffer "dictionary-overlay")


### PR DESCRIPTION
1. Provide overlay position options, either after original word or in help-echo
2. Make linter happy.
3. Remove redundant line.