### PR TITLE
hotfix: add property 'evaporate to overlay

### DIFF
--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -249,10 +249,11 @@ with `dictionary-overlay-render-buffer'."
   (let ((ov (make-overlay begin end)))
     (overlay-put ov 'face 'dictionary-overlay-unknownword)
     (pcase dictionary-overlay-position
-      ('after (overlay-put
-               ov 'after-string
-               (propertize (format dictionary-overlay-translation-format target)
-                           'face 'dictionary-overlay-translation)))
+      ('after (progn (overlay-put
+                      ov 'after-string
+                      (propertize (format dictionary-overlay-translation-format target)
+                                  'face 'dictionary-overlay-translation))
+                     (overlay-put ov 'evaporate t)))
       ('help-echo (overlay-put
                    ov 'help-echo
                    (format dictionary-overlay-translation-format target))))))


### PR DESCRIPTION
Make overlay disappear when original word is completely deleted. 
Fix issue https://github.com/ginqi7/dictionary-overlay/issues/36