### PR TITLE
feat: keymap for overlay; smart mark word; auto jump

### DIFF
--- a/README.org
+++ b/README.org
@@ -52,6 +52,8 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-jump-prev-unknown-word   | 跳转到上一个生词                                           |
 | dictionary-overlay-mark-word-known          | 标记当前单词为“已知”                                       |
 | dictionary-overlay-mark-word-unknown        | 标记当前单词为“生词”                                       |
+| dictionary-overlay-mark-word-smart          | 生词本模式时，默认标记当前单词为“未知”，透析模式时，标为“已知”    |
+| dictionary-overlay-mark-word-smart-reversely| 功能同上，但生词本模式时标记为“已知”，透析模式时，标为”未知“     |
 | dictionary-overlay-mark-buffer              | 标签当前 buffer 中所有未标记为“生词”的单词全为“已知”       |
 | dictionary-overlay-mark-buffer-unknown      | 标签当前 buffer 中所有未标记为“生词”的单词全为“未知”       |
 | dictionary-overlay-install                  | 安装 dictionary-overlay 所依赖的必选 python 包             |
@@ -65,6 +67,8 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-refresh-buffer-after-mark-word | t 时每次标记“单个词”都会重新渲染整个buffer, 默认为 t                |
 | dictionary-overlay-user-data-directory            | 用户数据存放 目录，默认值为：“~/.emacs.d/dictionary-overlay-data” |
 | dictionary-overlay-position                       | 显示翻译的位置：词后，help-echo, 默认在词后                       |
+| dictionary-overlay-inihibit-keymap                | t 时关闭 keymap, 默认为 nil                                    |
+| dictionary-overlay-mark-word-auto-jump            | t 时，首次渲染/刷新后标记单词时自动跳到下一个。之后根据的方向取决于是否使用了生词跳转 |
 | dictionary-overlay-translation-format             | 翻译展示的形式，默认是："(%s)"                                   |
 | dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                     |
 | dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |

--- a/README.org
+++ b/README.org
@@ -50,6 +50,7 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-toggle                   | 打开\关闭翻译渲染当前 buffer                               |
 | dictionary-overlay-jump-next-unknown-word   | 跳转到下一个生词                                           |
 | dictionary-overlay-jump-prev-unknown-word   | 跳转到上一个生词                                           |
+| dictionary-overlay-jump-out-overlay         | 光标跳到词末，离开overlay，恢复正常keymap                    |
 | dictionary-overlay-mark-word-known          | 标记当前单词为“已知”                                       |
 | dictionary-overlay-mark-word-unknown        | 标记当前单词为“生词”                                       |
 | dictionary-overlay-mark-word-smart          | 生词本模式时，默认标记当前单词为“未知”，透析模式时，标为“已知”    |

--- a/README.org
+++ b/README.org
@@ -68,7 +68,7 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-user-data-directory            | 用户数据存放 目录，默认值为：“~/.emacs.d/dictionary-overlay-data” |
 | dictionary-overlay-position                       | 显示翻译的位置：词后，help-echo, 默认在词后                       |
 | dictionary-overlay-inihibit-keymap                | t 时关闭 keymap, 默认为 nil                                    |
-| dictionary-overlay-mark-word-auto-jump            | t 时，首次渲染/刷新后标记单词时自动跳到下一个。之后根据的方向取决于是否使用了生词跳转 |
+| dictionary-overlay-auto-jump-after-mark-word      | t 时，首次渲染/刷新后标记单词时自动跳到下一个。之后根据的方向取决于是否使用了生词跳转 |
 | dictionary-overlay-translation-format             | 翻译展示的形式，默认是："(%s)"                                   |
 | dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                     |
 | dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -73,7 +73,7 @@
 ;;    unknown word after mark. If `dictionary-overlay-jump-prev-unknown-word' or
 ;;    `dictionary-overlay-jump-next-unknown-word' is used, the following jump direction
 ;;     changes accordingly.
-;;    default = t
+;;    default = nil
 ;;  `dictionary-overlay-inhibit-keymap'
 ;;    If t, show overlay for words in unknownwords list.
 ;;    default = t
@@ -171,7 +171,7 @@ of such packages."
   :group 'dictionary-overlay
   :type '(boolean))
 
-(defcustom dictionary-overlay-auto-jump-after-mark-word t
+(defcustom dictionary-overlay-auto-jump-after-mark-word nil
   "Auto jump to next unknown word after marking word.
 Usually, to the next unknown word."
   :group 'dictionary-overlay

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -68,7 +68,7 @@
 ;;  `dictionary-overlay-just-unknown-words'
 ;;    If t, show overlay for words in unknownwords list.
 ;;    default = t
-;;  `dictionary-overlay-mark-word-auto-jump'
+;;  `dictionary-overlay-auto-jump-after-mark-word'
 ;;    If t, for the first word after render/refresh, always auto jump to next
 ;;    unknown word after mark. If `dictionary-overlay-jump-prev-unknown-word' or
 ;;    `dictionary-overlay-jump-next-unknown-word' is used, the following jump direction
@@ -171,6 +171,15 @@ of such packages."
   :group 'dictionary-overlay
   :type '(boolean))
 
+(defcustom dictionary-overlay-auto-jump-after-mark-word t
+  "Auto jump to next unknown word after marking word.
+Usually, to the next unknown word."
+  :group 'dictionary-overlay
+  :type '(boolean))
+
+(defvar-local dictionary-overlay-jump-direction 'next
+  "Direction to jump word.")
+
 (defvar dictionary-overlay-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "r") #'dictionary-overlay-refresh-buffer)
@@ -242,15 +251,6 @@ You can re-bind the commands to any keys you prefer.")
     (remove-overlays)
     (websocket-bridge-call-buffer "render")))
 
-(defcustom dictionary-overlay-mark-word-auto-jump t
-  "Auto jump to next unknown word after marking word.
-Usually, to the next unknown word."
-  :group 'dictionary-overlay
-  :type '(boolean))
-
-(defvar-local dictionary-overlay-jump-direction 'next
-  "Direction to jump word.")
-
 (defun dictionary-overlay-jump-next-unknown-word ()
   "Jump to next unknown word."
   (interactive)
@@ -268,16 +268,16 @@ Usually, to the next unknown word."
 Usually overlay keymap has a higher priority than local major
 mode and minor mode key map. Jumping out of overlay facilitates the
 usage of original keymap. We say MAYBE, it means current approcach
-is imperfect."
+is imperfect. The command name is subjected to change depending on
+reliablity."
   (interactive)
-  ;; WIP 2022-11-25: need improvement? if so, PR is welcomed.
   (forward-word))
 
 (defun dictionary-overlay-mark-word-known ()
   "Mark current word known."
   (interactive)
   (websocket-bridge-call-word "mark_word_known")
-  (when dictionary-overlay-mark-word-auto-jump
+  (when dictionary-overlay-auto-jump-after-mark-word
     (pcase dictionary-overlay-jump-direction
       (`next (dictionary-overlay-jump-next-unknown-word))
       (`prev (dictionary-overlay-jump-prev-unknown-word))))
@@ -288,7 +288,7 @@ is imperfect."
   "Mark current word unknown."
   (interactive)
   (websocket-bridge-call-word "mark_word_unknown")
-  (when dictionary-overlay-mark-word-auto-jump
+  (when dictionary-overlay-auto-jump-after-mark-word
     (dictionary-overlay-jump-next-unknown-word))
   (when dictionary-overlay-refresh-buffer-after-mark-word
     (dictionary-overlay-refresh-buffer)))

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -44,8 +44,8 @@
 ;;    Mark current word known.
 ;;  `dictionary-overlay-mark-word-unknown'
 ;;    Mark current word unknown.
-;;  `dictionary-overlay-jump-out-of-overlay-maybe'
-;;    Try to leave overlay.
+;;  `dictionary-overlay-jump-out-of-overlay'
+;;    Move cursor out of overlay.
 ;;  `dictionary-overlay-mark-word-smart'
 ;;    Smartly mark current word as known or unknow.
 ;;  `dictionary-overlay-mark-word-smart-reversely'
@@ -187,7 +187,7 @@ Usually, to the next unknown word."
     (define-key map (kbd "n") #'dictionary-overlay-jump-next-unknown-word)
     (define-key map (kbd "m") #'dictionary-overlay-mark-word-smart)
     (define-key map (kbd "M") #'dictionary-overlay-mark-word-smart-reversely)
-    (define-key map (kbd "<escape>") #'dictionary-overlay-jump-out-of-overlay-maybe)
+    (define-key map (kbd "<escape>") #'dictionary-overlay-jump-out-of-overlay)
     map)
   "Keymap automatically activated inside overlays.
 You can re-bind the commands to any keys you prefer.")
@@ -263,13 +263,12 @@ You can re-bind the commands to any keys you prefer.")
   (websocket-bridge-call-buffer "jump_prev_unknown_word")
   (setq-local dictionary-overlay-jump-direction 'prev))
 
-(defun dictionary-overlay-jump-out-of-overlay-maybe ()
+(defun dictionary-overlay-jump-out-of-overlay ()
   "Jump out overlay so that we no longer in keymap.
 Usually overlay keymap has a higher priority than local major
 mode and minor mode key map. Jumping out of overlay facilitates the
-usage of original keymap. We say MAYBE, it means current approcach
-is imperfect. The command name is subjected to change depending on
-reliablity."
+usage of original keymap. The command name is subjected to change
+depending on reliablity."
   (interactive)
   (forward-word))
 

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -187,6 +187,7 @@ Usually, to the next unknown word."
     (define-key map (kbd "n") #'dictionary-overlay-jump-next-unknown-word)
     (define-key map (kbd "m") #'dictionary-overlay-mark-word-smart)
     (define-key map (kbd "M") #'dictionary-overlay-mark-word-smart-reversely)
+    (define-key map (kbd "c") #'dictionary-overlay-modify-translation)
     (define-key map (kbd "<escape>") #'dictionary-overlay-jump-out-of-overlay)
     map)
   "Keymap automatically activated inside overlays.

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -44,6 +44,12 @@
 ;;    Mark current word known.
 ;;  `dictionary-overlay-mark-word-unknown'
 ;;    Mark current word unknown.
+;;  `dictionary-overlay-jump-out-of-overlay-maybe'
+;;    Try to leave overlay.
+;;  `dictionary-overlay-mark-word-smart'
+;;    Smartly mark current word as known or unknow.
+;;  `dictionary-overlay-mark-word-smart-reversely'
+;;    Smartly mark current word as known or unknow, inverse version of the above.
 ;;  `dictionary-overlay-mark-buffer'
 ;;    Mark all words as known, except those in `unknownwords' list.
 ;;  `dictionary-overlay-mark-buffer-unknown'
@@ -60,6 +66,15 @@
 ;; Below are customizable option list:
 ;;
 ;;  `dictionary-overlay-just-unknown-words'
+;;    If t, show overlay for words in unknownwords list.
+;;    default = t
+;;  `dictionary-overlay-mark-word-auto-jump'
+;;    If t, for the first word after render/refresh, always auto jump to next
+;;    unknown word after mark. If `dictionary-overlay-jump-prev-unknown-word' or
+;;    `dictionary-overlay-jump-next-unknown-word' is used, the following jump direction
+;;     changes accordingly.
+;;    default = t
+;;  `dictionary-overlay-inhibit-keymap'
 ;;    If t, show overlay for words in unknownwords list.
 ;;    default = t
 ;;  `dictionary-overlay-refresh-buffer-after-mark-word'
@@ -146,6 +161,28 @@ with `dictionary-overlay-render-buffer'."
   :group 'dictionary-overlay
   :type '(string))
 
+;; SRC: ideas from `symbol-overlay', tip hat!
+(defcustom dictionary-overlay-inhibit-keymap nil
+  "When non-nil, don't use `dictionary-overlay-map'.
+This is intended for buffers/modes that use the keymap text
+property for their own purposes.  Because this package uses
+overlays it would always override the text property keymaps
+of such packages."
+  :group 'dictionary-overlay
+  :type '(boolean))
+
+(defvar dictionary-overlay-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "r") #'dictionary-overlay-refresh-buffer)
+    (define-key map (kbd "p") #'dictionary-overlay-jump-prev-unknown-word)
+    (define-key map (kbd "n") #'dictionary-overlay-jump-next-unknown-word)
+    (define-key map (kbd "m") #'dictionary-overlay-mark-word-smart)
+    (define-key map (kbd "M") #'dictionary-overlay-mark-word-smart-reversely)
+    (define-key map (kbd "<escape>") #'dictionary-overlay-jump-out-of-overlay-maybe)
+    map)
+  "Keymap automatically activated inside overlays.
+You can re-bind the commands to any keys you prefer.")
+
 (defun dictionary-overlay-start ()
   "Start dictionary-overlay."
   (interactive)
@@ -200,24 +237,50 @@ with `dictionary-overlay-render-buffer'."
 
 (defun dictionary-overlay-refresh-buffer ()
   "Refresh current buffer."
+  (interactive)
   (when dictionary-overlay-active-p
     (remove-overlays)
     (websocket-bridge-call-buffer "render")))
 
+(defcustom dictionary-overlay-mark-word-auto-jump t
+  "Auto jump to next unknown word after marking word.
+Usually, to the next unknown word."
+  :group 'dictionary-overlay
+  :type '(boolean))
+
+(defvar-local dictionary-overlay-jump-direction 'next
+  "Direction to jump word.")
+
 (defun dictionary-overlay-jump-next-unknown-word ()
   "Jump to next unknown word."
   (interactive)
-  (websocket-bridge-call-buffer "jump_next_unknown_word"))
+  (websocket-bridge-call-buffer "jump_next_unknown_word")
+  (setq-local dictionary-overlay-jump-direction 'next))
 
 (defun dictionary-overlay-jump-prev-unknown-word ()
   "Jump to prev unknown word."
   (interactive)
-  (websocket-bridge-call-buffer "jump_prev_unknown_word"))
+  (websocket-bridge-call-buffer "jump_prev_unknown_word")
+  (setq-local dictionary-overlay-jump-direction 'prev))
+
+(defun dictionary-overlay-jump-out-of-overlay-maybe ()
+  "Jump out overlay so that we no longer in keymap.
+Usually overlay keymap has a higher priority than local major
+mode and minor mode key map. Jumping out of overlay facilitates the
+usage of original keymap. We say MAYBE, it means current approcach
+is imperfect."
+  (interactive)
+  ;; WIP 2022-11-25: need improvement? if so, PR is welcomed.
+  (forward-word))
 
 (defun dictionary-overlay-mark-word-known ()
   "Mark current word known."
   (interactive)
   (websocket-bridge-call-word "mark_word_known")
+  (when dictionary-overlay-mark-word-auto-jump
+    (pcase dictionary-overlay-jump-direction
+      (`next (dictionary-overlay-jump-next-unknown-word))
+      (`prev (dictionary-overlay-jump-prev-unknown-word))))
   (when dictionary-overlay-refresh-buffer-after-mark-word
     (dictionary-overlay-refresh-buffer)))
 
@@ -225,12 +288,17 @@ with `dictionary-overlay-render-buffer'."
   "Mark current word unknown."
   (interactive)
   (websocket-bridge-call-word "mark_word_unknown")
+  (when dictionary-overlay-mark-word-auto-jump
+    (dictionary-overlay-jump-next-unknown-word))
   (when dictionary-overlay-refresh-buffer-after-mark-word
     (dictionary-overlay-refresh-buffer)))
 
 (defun dictionary-overlay-mark-word-smart ()
-  "Smartly mark current word known or unknown.
-Based on value of `dictionary-overlay-just-unknown-words'"
+  "Smartly mark current word as known or unknown.
+Based on value of `dictionary-overlay-just-unknown-words'
+Usually when value is t, we want to mark word as unknown. Vice versa.
+If you need reverse behavior, use:
+`dictionary-overlay-mark-word-smart-reversely' instead."
   (interactive)
   (if dictionary-overlay-just-unknown-words
       (dictionary-overlay-mark-word-unknown)
@@ -269,7 +337,9 @@ Based on value of `dictionary-overlay-just-unknown-words'"
                       ov 'after-string
                       (propertize (format dictionary-overlay-translation-format target)
                                   'face 'dictionary-overlay-translation))
-                     (overlay-put ov 'evaporate t)))
+                     (overlay-put ov 'evaporate t)
+                     (unless dictionary-overlay-inhibit-keymap
+                       (overlay-put ov 'keymap dictionary-overlay-map))))
       ('help-echo (overlay-put
                    ov 'help-echo
                    (format dictionary-overlay-translation-format target))))))

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -191,6 +191,22 @@ If nil, show overlay for words not in knownwords list."
   (websocket-bridge-call-word "mark_word_unknown")
   (dictionary-overlay-refresh-buffer))
 
+(defun dictionary-overlay-mark-word-smart ()
+  "Smartly mark current word known or unknown.
+Based on value of `dictionary-overlay-just-unknown-words'"
+  (interactive)
+  (if dictionary-overlay-just-unknown-words
+      (dictionary-overlay-mark-word-known)
+    (dictionary-overlay-mark-word-unknown)))
+
+(defun dictionary-overlay-mark-word-smart-reversely ()
+  "Smartly mark current word known or unknown smartly, but reversely.
+Based on value of `dictionary-overlay-just-unknown-words'"
+  (interactive)
+  (if dictionary-overlay-just-unknown-words
+      (dictionary-overlay-mark-word-unknown)
+    (dictionary-overlay-mark-word-known)))
+
 (defun dictionary-overlay-mark-buffer ()
   "Mark all words as known, except those in `unknownwords' list."
   (interactive)

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -196,16 +196,16 @@ If nil, show overlay for words not in knownwords list."
 Based on value of `dictionary-overlay-just-unknown-words'"
   (interactive)
   (if dictionary-overlay-just-unknown-words
-      (dictionary-overlay-mark-word-known)
-    (dictionary-overlay-mark-word-unknown)))
+      (dictionary-overlay-mark-word-unknown)
+    (dictionary-overlay-mark-word-known)))
 
 (defun dictionary-overlay-mark-word-smart-reversely ()
   "Smartly mark current word known or unknown smartly, but reversely.
 Based on value of `dictionary-overlay-just-unknown-words'"
   (interactive)
   (if dictionary-overlay-just-unknown-words
-      (dictionary-overlay-mark-word-unknown)
-    (dictionary-overlay-mark-word-known)))
+      (dictionary-overlay-mark-word-known)
+    (dictionary-overlay-mark-word-unknown)))
 
 (defun dictionary-overlay-mark-buffer ()
   "Mark all words as known, except those in `unknownwords' list."


### PR DESCRIPTION
1. add keymap `dictionary-overlay-mode-map` for overlay: cursor at word, keymap is enabled. the priority of the keymap is higher than minor mode, if one wants minor mode to work, move cursor out of the overlay, either by mouse clicking somewhere not overlay rendered, or command `dictionary-overlay-jump-out-of-overlay-maybe`, even dislike the keymap at all, just disable it with `(setq dictionary-overlay-inhibit-keymap nil)`
2. auto jump to next or previous unknown word after mark word as known or unknown. there's option to disable it, with `(setq dictionary-overlay-mark-word-auto-jump nil)`. Direction is controlled by `dictionary-overlay-jump-direction`, For the first word after rendering/re-rendering/refresh, cursor will always move to next word. From 2nd word on, direction may change depending on usage of 'dictionary-overlay-jump-next/prev-unknown-word'.
3. smart mark word `dictionary-overlay-mark-word-smart(-reversely)` depends on what mode is on, that is, the value of 'dictionary-overlay-just-unknown-words'. When `t`, mark word as unknown; otherwise mark as known. Also provided is, `dictionary-overlay-mark-word-smart-reversely` for opposite behavior.