### PR TITLE
Remove dictionary-overlay-refresh-buffer-after-mark-word

### DIFF
--- a/README.org
+++ b/README.org
@@ -65,7 +65,6 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 
 | 选项                                               | 说明                                                          |
 | dictionary-overlay-just-unknown-words             | t 时使用“生词本”模式，nil 为“透析阅读”模式，默认为 t                |
-| dictionary-overlay-refresh-buffer-after-mark-word | t 时每次标记“单个词”都会重新渲染整个buffer, 默认为 t                |
 | dictionary-overlay-user-data-directory            | 用户数据存放 目录，默认值为：“~/.emacs.d/dictionary-overlay-data” |
 | dictionary-overlay-position                       | 显示翻译的位置：词后，help-echo, 默认在词后                       |
 | dictionary-overlay-inihibit-keymap                | t 时关闭 keymap, 默认为 nil                                    |
@@ -125,8 +124,6 @@ face `dictionary-overlay-unknownword` 如果用户不自行定义，那么不会
 当一个生词反复出现，你觉得自己已经认识了它，可以标记为 known （ ~dictionary-overlay-mark-word-known~ ），下次不再展示翻译。
 
 当你阅读了足够多的文章，你应该积累了一定量的 known-words ，此时，或许你可以尝试使用"透析阅读法"（ ~(setq dictionary-overlay-just-unknown-words nil)~ ）将自动展示，“或许”你不认识的单词。
-
-当前 buffer 有大量生词时，重新渲染整个界面会产生可感知的渲染延迟，此时可将 dictionary-overlay-refresh-buffer-after-mark-word 的值设为 nil, 界面不再刷新，但词汇依然会进入生词本和熟词本，如果标记几个词后想刷新界面，可使用命令 dictionary-overlay-render-buffer。
 
 如果喜欢最小的视觉干扰，可以通过 (setq dictionary-overlay-position 'help-echo) 把翻译位置设置在 help-echo 里，只有鼠标通过时才显示释义。注意：目前支持的释义仍过于简单，并不推荐使用此法，同时由于默认无face，推荐设置前述 (copy-face 'font-lock-keyword-face 'dictionary-overlay-unknownword)。
 

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -77,11 +77,6 @@
 ;;  `dictionary-overlay-inhibit-keymap'
 ;;    If t, show overlay for words in unknownwords list.
 ;;    default = t
-;;  `dictionary-overlay-refresh-buffer-after-mark-word'
-;;    If t, refresh buffer if marking word with:
-;;    `dictionary-overlay-mark-word-known' and
-;;    `dictionary-overlay-mark-word-unknown'
-;;    default = t
 ;;  `dictionary-overlay-position'
 ;;    If value is 'after, put translation after word
 ;;    If value is 'help-echo, show it when mouse over word
@@ -149,14 +144,6 @@ If value is \\='help-echo, show it when mouse over word."
   :type '(choice
           (cons :tag "Show after word" 'after)
           (cons :tag "Show in help-echo" 'help-echo)))
-
-(defcustom dictionary-overlay-refresh-buffer-after-mark-word t
-  "Refresh buffer or not after marking word as known or unknown.
-Since overlay re-rendering for the whole buffer and word processing
-simultaneously causes noticeable flickering. Refresh buffer manually
-with `dictionary-overlay-render-buffer'."
-  :group 'dictionary-overlay
-  :type '(boolean))
 
 (defcustom dictionary-overlay-user-data-directory
   (locate-user-emacs-file "dictionary-overlay-data/")
@@ -321,8 +308,7 @@ depending on reliablity."
        (dictionary-overlay-jump-next-unknown-word))
       (`prev
        (dictionary-overlay-jump-prev-unknown-word))))
-  (when dictionary-overlay-refresh-buffer-after-mark-word
-    (dictionary-overlay-refresh-buffer)))
+  (dictionary-overlay-refresh-buffer))
 
 (defun dictionary-overlay-mark-word-unknown ()
   "Mark current word unknown."
@@ -330,8 +316,7 @@ depending on reliablity."
   (websocket-bridge-call-word "mark_word_unknown")
   (when dictionary-overlay-auto-jump-after-mark-word
     (dictionary-overlay-jump-next-unknown-word))
-  (when dictionary-overlay-refresh-buffer-after-mark-word
-    (dictionary-overlay-refresh-buffer)))
+  (dictionary-overlay-refresh-buffer))
 
 (defun dictionary-overlay-mark-word-smart ()
   "Smartly mark current word as known or unknown.


### PR DESCRIPTION
Since it's a workaround for previous overlay rendering, no longer needed after introduction of hash-table.
Big shoutout to @ginqi7 .