### PR TITLE
Revamp auto jump, add recenter

### DIFF
--- a/README.org
+++ b/README.org
@@ -68,7 +68,7 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-user-data-directory            | 用户数据存放 目录，默认值为：“~/.emacs.d/dictionary-overlay-data” |
 | dictionary-overlay-position                       | 显示翻译的位置：词后，help-echo, 默认在词后                       |
 | dictionary-overlay-inihibit-keymap                | t 时关闭 keymap, 默认为 nil                                    |
-| dictionary-overlay-auto-jump-after-mark-word      | t 时，首次渲染/刷新后标记单词时自动跳到下一个。之后根据的方向取决于是否使用了生词跳转 |
+| dictionary-overlay-auto-jump-after                | 可选项：1. 标记单词后(mark-word)，2. 刷新(refresh-buffer)        |
 | dictionary-overlay-translation-format             | 翻译展示的形式，默认是："(%s)"                                   |
 | dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                     |
 | dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |

--- a/README.org
+++ b/README.org
@@ -69,6 +69,7 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-position                       | 显示翻译的位置：词后，help-echo, 默认在词后                       |
 | dictionary-overlay-inihibit-keymap                | t 时关闭 keymap, 默认为 nil                                    |
 | dictionary-overlay-auto-jump-after-mark-word      | t 时，首次渲染/刷新后标记单词时自动跳到下一个。之后根据的方向取决于是否使用了生词跳转 |
+| dictionary-overlay-recenter-after-mark-and-jump   | t 时，标记或跳转时自动上下居中                                    |
 | dictionary-overlay-translation-format             | 翻译展示的形式，默认是："(%s)"                                   |
 | dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                     |
 | dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -181,6 +181,11 @@ Usually, to the next unknown word."
 (defvar-local dictionary-overlay-jump-direction 'next
   "Direction to jump word.")
 
+(defcustom dictonary-overlay-recenter-after-mark-and-jump nil
+  "Recenter after mark or jump."
+  :group 'dictionary-overlay
+  :type '(boolean))
+
 (defvar dictionary-overlay-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "r") #'dictionary-overlay-refresh-buffer)
@@ -281,13 +286,17 @@ You can re-bind the commands to any keys you prefer.")
   "Jump to next unknown word."
   (interactive)
   (websocket-bridge-call-buffer "jump_next_unknown_word")
-  (setq-local dictionary-overlay-jump-direction 'next))
+  (setq-local dictionary-overlay-jump-direction 'next)
+  (when dictonary-overlay-recenter-after-mark-and-jump
+    (recenter-top-bottom 20)))
 
 (defun dictionary-overlay-jump-prev-unknown-word ()
   "Jump to prev unknown word."
   (interactive)
   (websocket-bridge-call-buffer "jump_prev_unknown_word")
-  (setq-local dictionary-overlay-jump-direction 'prev))
+  (setq-local dictionary-overlay-jump-direction 'prev)
+  (when dictonary-overlay-recenter-after-mark-and-jump
+    (recenter-top-bottom 20)))
 
 (defun dictionary-overlay-jump-out-of-overlay ()
   "Jump out overlay so that we no longer in keymap.
@@ -308,7 +317,10 @@ depending on reliablity."
        (dictionary-overlay-jump-next-unknown-word))
       (`prev
        (dictionary-overlay-jump-prev-unknown-word))))
-  (dictionary-overlay-refresh-buffer))
+  (when dictionary-overlay-refresh-buffer-after-mark-word
+    (dictionary-overlay-refresh-buffer))
+  (when dictonary-overlay-recenter-after-mark-and-jump
+    (recenter-top-bottom 20)))
 
 (defun dictionary-overlay-mark-word-unknown ()
   "Mark current word unknown."
@@ -316,7 +328,10 @@ depending on reliablity."
   (websocket-bridge-call-word "mark_word_unknown")
   (when dictionary-overlay-auto-jump-after-mark-word
     (dictionary-overlay-jump-next-unknown-word))
-  (dictionary-overlay-refresh-buffer))
+  (when dictionary-overlay-refresh-buffer-after-mark-word
+    (dictionary-overlay-refresh-buffer))
+  (when dictonary-overlay-recenter-after-mark-and-jump
+    (recenter-top-bottom 20)))
 
 (defun dictionary-overlay-mark-word-smart ()
   "Smartly mark current word as known or unknown.

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -81,6 +81,9 @@
 ;;    If value is 'after, put translation after word
 ;;    If value is 'help-echo, show it when mouse over word
 ;;    default = 'after
+;;  `dictonary-overlay-recenter-after-mark-and-jump'
+;;    If t, recenter after mark or jump.
+;;    default is nil
 ;;  `dictionary-overlay-user-data-directory'
 ;;    Place user data in Emacs directory.
 ;;    default = (locate-user-emacs-file "dictionary-overlay-data/")
@@ -288,7 +291,7 @@ You can re-bind the commands to any keys you prefer.")
   (websocket-bridge-call-buffer "jump_next_unknown_word")
   (setq-local dictionary-overlay-jump-direction 'next)
   (when dictonary-overlay-recenter-after-mark-and-jump
-    (recenter-top-bottom 20)))
+    (recenter)))
 
 (defun dictionary-overlay-jump-prev-unknown-word ()
   "Jump to prev unknown word."
@@ -296,7 +299,7 @@ You can re-bind the commands to any keys you prefer.")
   (websocket-bridge-call-buffer "jump_prev_unknown_word")
   (setq-local dictionary-overlay-jump-direction 'prev)
   (when dictonary-overlay-recenter-after-mark-and-jump
-    (recenter-top-bottom 20)))
+    (recenter)))
 
 (defun dictionary-overlay-jump-out-of-overlay ()
   "Jump out overlay so that we no longer in keymap.
@@ -317,10 +320,9 @@ depending on reliablity."
        (dictionary-overlay-jump-next-unknown-word))
       (`prev
        (dictionary-overlay-jump-prev-unknown-word))))
-  (when dictionary-overlay-refresh-buffer-after-mark-word
-    (dictionary-overlay-refresh-buffer))
+  (dictionary-overlay-refresh-buffer)
   (when dictonary-overlay-recenter-after-mark-and-jump
-    (recenter-top-bottom 20)))
+    (recenter)))
 
 (defun dictionary-overlay-mark-word-unknown ()
   "Mark current word unknown."
@@ -328,10 +330,9 @@ depending on reliablity."
   (websocket-bridge-call-word "mark_word_unknown")
   (when dictionary-overlay-auto-jump-after-mark-word
     (dictionary-overlay-jump-next-unknown-word))
-  (when dictionary-overlay-refresh-buffer-after-mark-word
-    (dictionary-overlay-refresh-buffer))
+  (dictionary-overlay-refresh-buffer)
   (when dictonary-overlay-recenter-after-mark-and-jump
-    (recenter-top-bottom 20)))
+    (recenter)))
 
 (defun dictionary-overlay-mark-word-smart ()
   "Smartly mark current word as known or unknown.


### PR DESCRIPTION
1. Revamp auto jump, to change the variable `dictionary-overlay-auto-jump-after-mark-word` to `dictionary-overlay-auto-jump-after`, it repeatedly takes options, 'mark-word, or 'refresh-buffer, or both of them.  Default is `'()`.
2. Add option: `dictionary-overlay-recenter-after-mark-and-jump`, which is self-explained by its name.  NOTE: `recenter` doesn't play well internally when there's picture in buffer. That being said, at least it works. Default is nil.
3. with these 2 options, one could always stay within the world of overlay, and use the keymap to deal with words.
