### PR TITLE
Add options: jump to first or last unknown word

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,6 +50,8 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-toggle                   | 打开\关闭翻译渲染当前 buffer                               |
 | dictionary-overlay-jump-next-unknown-word   | 跳转到下一个生词                                           |
 | dictionary-overlay-jump-prev-unknown-word   | 跳转到上一个生词                                           |
+| dictionary-overlay-jump-first-unknown-word  | 跳转到第一个生词                                           |
+| dictionary-overlay-jump-last-unknown-word   | 跳转到最后一个生词                                          |
 | dictionary-overlay-jump-out-overlay         | 光标跳到词末，离开overlay，恢复正常keymap                    |
 | dictionary-overlay-mark-word-known          | 标记当前单词为“已知”                                       |
 | dictionary-overlay-mark-word-unknown        | 标记当前单词为“生词”                                       |
@@ -106,6 +108,8 @@ face `dictionary-overlay-unknownword` 如果用户不自行定义，那么不会
 | (kbd "r")        | dictionary-overlay-refresh-buffer            | 刷新buffer                                   |
 | (kbd "p")        | dictionary-overlay-jump-prev-unknown-word    | 跳转到上一个生词                             |
 | (kbd "n")        | dictionary-overlay-jump-next-unknown-word    | 跳转到下一个生词                             |
+| (kbd "p")        | dictionary-overlay-jump-first-unknown-word   | 跳转到第一个生词                             |
+| (kbd "n")        | dictionary-overlay-jump-last-unknown-word    | 跳转到最后一个生词                           |
 | (kbd "m")        | dictionary-overlay-mark-word-smart           | 透析模式，把单词标记为“熟词”                 |
 | (kbd "M")        | dictionary-overlay-mark-word-smart-reversely | 生词本模式，把单词标记为“熟词”               |
 | (kbd "c")        | dictionary-overlay-modify-translation        | 修改翻译                                     |

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -40,6 +40,10 @@
 ;;    Jump to next unknown word.
 ;;  `dictionary-overlay-jump-prev-unknown-word'
 ;;    Jump to prev unknown word.
+;;  `dictionary-overlay-jump-first-unknown-word'
+;;    Jump to first unknown word.
+;;  `dictionary-overlay-jump-last-unknown-word'
+;;    Jump to last unknown word.
 ;;  `dictionary-overlay-mark-word-known'
 ;;    Mark current word known.
 ;;  `dictionary-overlay-mark-word-unknown'
@@ -184,22 +188,14 @@ Usually, to the next unknown word."
 (defvar dictionary-overlay-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "r") #'dictionary-overlay-refresh-buffer)
-    (define-key map
-                (kbd "p")
-                #'dictionary-overlay-jump-prev-unknown-word)
-    (define-key map
-                (kbd "n")
-                #'dictionary-overlay-jump-next-unknown-word)
+    (define-key map (kbd "p") #'dictionary-overlay-jump-prev-unknown-word)
+    (define-key map (kbd "n") #'dictionary-overlay-jump-next-unknown-word)
+    (define-key map (kbd "<") #'dictionary-overlay-jump-first-unknown-word)
+    (define-key map (kbd ">") #'dictionary-overlay-jump-last-unknown-word)
     (define-key map (kbd "m") #'dictionary-overlay-mark-word-smart)
-    (define-key map
-                (kbd "M")
-                #'dictionary-overlay-mark-word-smart-reversely)
-    (define-key map
-                (kbd "c")
-                #'dictionary-overlay-modify-translation)
-    (define-key map
-                (kbd "<escape>")
-                #'dictionary-overlay-jump-out-of-overlay)
+    (define-key map (kbd "M") #'dictionary-overlay-mark-word-smart-reversely)
+    (define-key map (kbd "c") #'dictionary-overlay-modify-translation)
+    (define-key map (kbd "<escape>") #'dictionary-overlay-jump-out-of-overlay)
     map)
   "Keymap automatically activated inside overlays.
 You can re-bind the commands to any keys you prefer.")
@@ -288,6 +284,22 @@ You can re-bind the commands to any keys you prefer.")
   (interactive)
   (websocket-bridge-call-buffer "jump_prev_unknown_word")
   (setq-local dictionary-overlay-jump-direction 'prev))
+
+(defun dictionary-overlay-jump-first-unknown-word ()
+  "Jump to first unknown word."
+  (interactive)
+  (goto-char
+   (string-to-number
+    (car (string-split
+          (car (last dictionary-overlay-hash-table-keys)) ":" t)))))
+
+(defun dictionary-overlay-jump-last-unknown-word ()
+  "Jump to last unknown word."
+  (interactive)
+  (goto-char
+   (string-to-number
+    (car (string-split
+          (car dictionary-overlay-hash-table-keys) ":" t)))))
 
 (defun dictionary-overlay-jump-out-of-overlay ()
   "Jump out overlay so that we no longer in keymap.


### PR DESCRIPTION
Add support for jumping to first or last unknown word.
For both commands, the cursor will be at the beginning of the word.
Close https://github.com/ginqi7/dictionary-overlay/issues/41.