### PR TITLE
Hotfix: update options of `dictionary-overlay-auto-jump-after'

### DIFF
--- a/README.org
+++ b/README.org
@@ -70,7 +70,7 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-user-data-directory            | 用户数据存放 目录，默认值为：“~/.emacs.d/dictionary-overlay-data” |
 | dictionary-overlay-position                       | 显示翻译的位置：词后，help-echo, 默认在词后                       |
 | dictionary-overlay-inihibit-keymap                | t 时关闭 keymap, 默认为 nil                                    |
-| dictionary-overlay-auto-jump-after                | 可选项：1. 标记单词后(mark-word)，2. 刷新(refresh-buffer)        |
+| dictionary-overlay-auto-jump-after                | 可选项：标为生词 mark-word-known, 标为熟词 mark-word-unknwon, 刷新 render-buffer |
 | dictionary-overlay-translation-format             | 翻译展示的形式，默认是："(%s)"                                   |
 | dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                     |
 | dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |


### PR DESCRIPTION
Hotfix for #44 .
Previously, usage of option: `(setq dictionary-overlay-auto-jump-after '(refresh-buffer)` is overkilled, since it is intertwined with dictionary-overlay-mark-word-(un)known, which brings unexpected behaviors. So tone down `'refresh-buffer` to `'render-buffer` would be much more appropriate.

