### PR TITLE
Add support for lookup word

### DIFF
--- a/README.org
+++ b/README.org
@@ -48,6 +48,7 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 | dictionary-overlay-restart                  | 重启 dictionary-overlay 应用                               |
 | dictionary-overlay-render-buffer            | 使用翻译渲染当前 buffer                                    |
 | dictionary-overlay-toggle                   | 打开\关闭翻译渲染当前 buffer                               |
+| dictionary-overlay-lookup                   | 查询当前词, 默认 Emacs 自带词典。自定义见选项
 | dictionary-overlay-jump-next-unknown-word   | 跳转到下一个生词                                           |
 | dictionary-overlay-jump-prev-unknown-word   | 跳转到上一个生词                                           |
 | dictionary-overlay-jump-first-unknown-word  | 跳转到第一个生词                                           |
@@ -66,17 +67,25 @@ git clone --depth=1 -b main https://github.com/ginqi7/dictionary-overlay ~/.emac
 * 选项
 
 | 选项                                               | 说明                                                          |
+|---------------------------------------------------+---------------------------------------------------------------|
 | dictionary-overlay-just-unknown-words             | t 时使用“生词本”模式，nil 为“透析阅读”模式，默认为 t                |
 | dictionary-overlay-user-data-directory            | 用户数据存放 目录，默认值为：“~/.emacs.d/dictionary-overlay-data” |
 | dictionary-overlay-position                       | 显示翻译的位置：词后，help-echo, 默认在词后                       |
+| dictionary-overlay-lookup-with                    | 查词词典设置：默认系统词典。可自定义第三方包，比如 youdao-dictionary, popweb |
 | dictionary-overlay-inihibit-keymap                | t 时关闭 keymap, 默认为 nil                                    |
 | dictionary-overlay-auto-jump-after                | 可选项：标为生词 mark-word-known, 标为熟词 mark-word-unknwon, 刷新 render-buffer |
 | dictionary-overlay-translation-format             | 翻译展示的形式，默认是："(%s)"                                   |
-| dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                     |
-| dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |
+
+
+
 
 
 ** face
+
+| 选项                                               | 说明                                                          |
+|---------------------------------------------------+---------------------------------------------------------------|
+| dictionary-overlay-unknownword                    | 生词的展示形态 face 默认为 nil, 用户可自行修改                     |
+| dictionary-overlay-translation                    | 生词的翻译的展示形态 face 默认为 nil, 用户可自行修改                |
 
 用于控制生词的展示, 为了不影响阅读默认为空，不对原始 face 做任何修改。如果希望能通过 face 对生词进行显示增加可以参考
 
@@ -105,14 +114,15 @@ face `dictionary-overlay-unknownword` 如果用户不自行定义，那么不会
 * 快捷键
 当 ~(setq dictionary-overlay-inihibit-keymap nil)~ 可以使用若干自带的快捷键，当point 在一个生词的overlay 之上时，可以：
 
-| (kbd "r")        | dictionary-overlay-refresh-buffer            | 刷新buffer                                   |
+| (kbd "d")        | dictionary-overlay-lookup                    | 查当前词                                     |
+| (kbd "r")        | dictionary-overlay-refresh-buffer            | 刷新buffer                                  |
 | (kbd "p")        | dictionary-overlay-jump-prev-unknown-word    | 跳转到上一个生词                             |
 | (kbd "n")        | dictionary-overlay-jump-next-unknown-word    | 跳转到下一个生词                             |
 | (kbd "p")        | dictionary-overlay-jump-first-unknown-word   | 跳转到第一个生词                             |
 | (kbd "n")        | dictionary-overlay-jump-last-unknown-word    | 跳转到最后一个生词                           |
 | (kbd "m")        | dictionary-overlay-mark-word-smart           | 透析模式，把单词标记为“熟词”                 |
 | (kbd "M")        | dictionary-overlay-mark-word-smart-reversely | 生词本模式，把单词标记为“熟词”               |
-| (kbd "c")        | dictionary-overlay-modify-translation        | 修改翻译                                     |
+| (kbd "c")        | dictionary-overlay-modify-translation        | 修改翻译                                  |
 | (kbd "<escape>") | dictionary-overlay-jump-out-of-overlay       | 跳出overlay 让快捷键在非overlay 词语中失效。 |
 
 快捷键只在标记为生词的overlay 上生效，因此 ~dictionary-overlay-mark-word-unknown~ 还需要自行绑定需要的快捷键

--- a/dictionary-overlay.el
+++ b/dictionary-overlay.el
@@ -58,6 +58,8 @@
 ;;    Mark all words as known, except those in `unknownwords' list.
 ;;  `dictionary-overlay-mark-buffer-unknown'
 ;;    Mark all words as unknown, except those in `unknownwords' list.
+;;  `dictionary-overlay-lookup'
+;;    Look up word at cursor
 ;;  `dictionary-overlay-install'
 ;;    Install all python dependencies.
 ;;  `dictionary-overlay-install-google-translate'
@@ -201,6 +203,11 @@ next overlay."
   :group 'dictionary-overlay
   :type '(boolean))
 
+(defcustom dictionary-overlay-lookup-with dictionary-lookup-definition
+  "Look up word with fn."
+  :group 'dictionary-overlay
+  :type '(function))
+
 (defvar dictionary-overlay-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "r") #'dictionary-overlay-refresh-buffer)
@@ -210,6 +217,7 @@ next overlay."
     (define-key map (kbd ">") #'dictionary-overlay-jump-last-unknown-word)
     (define-key map (kbd "m") #'dictionary-overlay-mark-word-smart)
     (define-key map (kbd "M") #'dictionary-overlay-mark-word-smart-reversely)
+    (define-key map (kbd "d") #'dictionary-overlay-lookup)
     (define-key map (kbd "c") #'dictionary-overlay-modify-translation)
     (define-key map (kbd "<escape>") #'dictionary-overlay-jump-out-of-overlay)
     map)
@@ -390,6 +398,14 @@ Based on value of `dictionary-overlay-just-unknown-words'"
          "Mark all as UNKNOWN, EXCEPT those in unknownwords list?")
     (websocket-bridge-call-buffer "mark_buffer_unknown")
     (dictionary-overlay-refresh-buffer)))
+
+(defun dictionary-overlay-lookup ()
+  "Look up word.
+NOTE: third party dictionaries have their own implemention of
+getting words. Probably the word will be the same as the one
+dictionary-overlay gets."
+  (interactive)
+  (funcall dictionary-overlay-lookup-with))
 
 (defun dictionary-add-overlay-from (begin end source target)
   "Add a overlay with range BEGIN to END for the translation SOURCE to TARGET."


### PR DESCRIPTION
1. function: dictionary-overlay-lookup
2. options: dictionary-overlay-lookup-with, default: nil a. value type: 'function, so customization is available b. e.g., Built-in (Emacs 29 only?): dictionary-lookup-definition, Third Parties youdao-dictionary-search-at-point, youdao-dictionary-search-at-point+, youdao-dictionary-search-at-point-tooltip, youdao-dictionary-search-at-point-posframe, youdao-dictionary-play-voice-at-point, etc.
   c. keymap support: "d" for mnemonic - dictionary

#50 