### PR TITLE
Ommit "word" with digitals or underlines

### DIFF
--- a/dictionary-overlay.py
+++ b/dictionary-overlay.py
@@ -42,7 +42,7 @@ async def parse(sentence: str):
 def new_word_p(word: str) -> bool:
     if len(word) < 3:
         return False
-    if re.match(r"[\W\d]", word, re.M | re.I):
+    if re.match(r".*[^a-z].*", word, re.M | re.I):
         return False
     return not in_or_stem_in(word, known_words)
 


### PR DESCRIPTION
After change, these previously defined as "word"s, are not ommitted:

"
a103ec
c4e30a
random_words_test
utm_content
"

These "words" usually appear in URLs, git commits, code blocks.