### PR TITLE
Remove sexpdata version limit.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sexpdata==0.0.3
+sexpdata
 six==1.16.0
 snowballstemmer==2.2.0
 tokenizers==0.13.2


### PR DESCRIPTION
sexpdata 1.0.0 已经修复了 symbol value is undefine 的问题了， 不需要限制版本号了。